### PR TITLE
Remove spring.data.mongodb.uri from application.properties

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.7.7</version>
+        <version>3.0.0</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
     <groupId>de.neuefische</groupId>
@@ -40,7 +40,8 @@
 
         <dependency>
             <groupId>de.flapdoodle.embed</groupId>
-            <artifactId>de.flapdoodle.embed.mongo</artifactId>
+            <artifactId>de.flapdoodle.embed.mongo.spring30x</artifactId>
+            <version>4.3.2</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,2 +1,1 @@
-spring.data.mongodb.uri=mongodb://localhost:27017/vehicles
-spring.mongodb.embedded.version=6.0.1
+de.flapdoodle.mongodb.embedded.version=6.0.1


### PR DESCRIPTION
If you use the new flapdoodle project dedicated to spring boot 3.0 
AND remove the spring.data.mongodb.uri from your application.properties, it looks like flapdoodle is working.

Im not sure why exactly this works and if there are other ways...